### PR TITLE
[🔨 Fix] prettier 포맷팅 모든 파일에서 JS로만 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"server": "node server/index.js",
 		"build": "vite build",
 		"preview": "vite preview",
-		"format": "prettier --cache --write .",
+		"format": "prettier --write \"**/*.js\"",
 		"lint": "eslint --cache .",
 		"prepare": "husky"
 	},


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[prettier 포맷팅 모든 파일에서 JS로만 변경]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
- prettier 포맷팅 모든 파일에서 JS로만 변경

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.

- package.json 파일 "format": "prettier --cache --write .",에서<br> "format": "prettier --write \"**/*.js\"",


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

기본 prettier formatting이 yml 및 css 등 다른 파일에도 적용 되었었는데 해당 명령어로 js에만 적용하게 변경하였습니다.
기존 lint-staged에 설정이 있었는데 일단 적용 되지 않았던 것 같아서 npm run format쪽 명령어에 추가하였습니다.

close #39 
