### PR TITLE
[🐞 Bug] 메인페이지(마이페이지)에서 다른 페이지로 이동시 MyPage.updateCurrentTime 오류가 생김

### DIFF
--- a/src/pages/mypage/index.js
+++ b/src/pages/mypage/index.js
@@ -4,6 +4,7 @@ export default class MyPage {
 	constructor() {
 		// Bind the update time method to the instance
 		this.updateCurrentTime = this.updateCurrentTime.bind(this);
+		this.intervalId = null; // setInterval ID 저장할 변수
 	}
 
 	render() {
@@ -131,13 +132,15 @@ export default class MyPage {
 		document.querySelector('#pageContents').innerHTML = content;
 
 		this.startClock();
+		this.checkUrlChange(); // URL 변경 감지 시작
 
 		return content;
 	}
 
+	// 기존 인터벌Id를 저장하고 컨트롤 할 수 있게 변경
 	startClock() {
 		this.updateCurrentTime();
-		setInterval(this.updateCurrentTime, 1000);
+		this.intervalId = setInterval(this.updateCurrentTime, 1000); // Interval ID 저장
 	}
 
 	updateCurrentTime() {
@@ -162,10 +165,20 @@ export default class MyPage {
 
 		currentTimeElement.textContent = `${formattedDate} | ${formattedTime}`;
 	}
-}
 
-// 페이지 로드 후 MyPage 초기화
-window.onload = () => {
-	const myPage = new MyPage();
-	myPage.render();
-};
+	// URL 변경을 감지하고, 변경 시 clearClock을 호출
+	checkUrlChange() {
+		const checkInterval = setInterval(() => {
+			if (this.currentUrl !== window.location.href) {
+				this.stopIntevalTimer(); // URL이 변경되면 clearClock 호출
+				clearInterval(checkInterval); // Interval 해제
+			}
+		}, 1000); // 0.5초마다 URL 변경 체크
+	}
+
+	stopIntevalTimer() {
+		if (this.intervalId) {
+			clearInterval(this.intervalId);
+		}
+	}
+}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[메인에서 페이지 이동시 생성되는 오류 수정]**

## 📋 작업 내용

- 시계 변경을 위한 Interval 타이머 다른 페이지로 이동시 작동 안하게 변경

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.
- [ ] checkUrlChange() 메소드 추가
- [ ] stopIntevalTimer() 메소드 추가
- [ ] startClock() 메소드 내부에 intervalId를 객체로 저장으로 변경


## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/83169a2c-4a54-4c9c-be38-62463c1d1f7f)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
