### PR TITLE
[✨ Feature] 근태 신청 페이지 신청 내역 모달 구현 #74

### DIFF
--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -31,6 +31,5 @@ export const handlers = [
 		);
 
 		return response;
-
 	}),
 ];

--- a/src/pages/vacation/VacationApplyModal.js
+++ b/src/pages/vacation/VacationApplyModal.js
@@ -42,6 +42,7 @@ export default class VacationApplyModal {
 
 	async handleVacationSubmit(event) {
 		event.preventDefault();
+		const vacationApplyModal = document.getElementById('applyModal');
 		const submitArray = [];
 		const submitObject = {};
 		const formData = new FormData(this);
@@ -60,6 +61,8 @@ export default class VacationApplyModal {
 			},
 			body: toJSON,
 		});
+
+		vacationApplyModal.classList.remove('active');
 	}
 
 	async render() {

--- a/src/pages/vacation/VacationHistoryModal.js
+++ b/src/pages/vacation/VacationHistoryModal.js
@@ -1,6 +1,7 @@
 export default class VacationHistoryModal {
-	constructor(modalWrapper) {
+	constructor(modalWrapper, foundData) {
 		this.modalWrapper = modalWrapper;
+		this.foundData = foundData;
 		this.template = `
         <div id="historyModal" class="vacation__history-wrapper">
             <div class="vacation__history-background"></div>
@@ -10,18 +11,14 @@ export default class VacationHistoryModal {
                 </div>
                 <div class="vacation__history-author-wrapper">
                     <hr>
-                    <h3 class="vacation__history-author">박수빈</h3>
+                    <h3 class="vacation__history-author">${foundData[0].username}</h3>
                 </div>
                 <div class="vacation__history-form-wrapper">
                     <form action="" class="form">
                         <fieldset class="vacation__apply-select">
                             <legend>신청가능한 근태</legend>
                             <label for="apply">휴가 종류</label>
-                            <select name="apply" id="apply" readonly>
-                                <option value="연차">🏖️ 연차</option>
-                                <option value="반차">🌇 반차</option>
-                                <option value="병가">🚑 병가</option>
-                                <option value="기타">💬 기타</option>
+                            <select name="apply" id="vacationSelect" readonly>
                             </select>
                         </fieldset>
                         <fieldset>
@@ -32,12 +29,11 @@ export default class VacationHistoryModal {
                             <legend>종료일</legend>
                             <input type="date" data-placeholder="종료일" placeholder="종료일" required readonly>
                         </fieldset>
-                        <input type="text" readonly>
-                        <textarea name="" id="" readonly>이런 이런 이런 이유로 ~~~ 휴가 신청합니다 ~</textarea>
+                        <input id="title" type="text"   readonly>
+                        <textarea name="" id="" readonly></textarea>
                     </form>
                 </div>
                 <div id="historyModalBtnWrapper" class="vacation__history-btn-wrapper">
-                    <button class="btn">취소</button>
                     <button class="btn btn--primary">확인</button>
                 </div>
             </div>
@@ -45,7 +41,61 @@ export default class VacationHistoryModal {
         `;
 	}
 
+	setRequestType() {
+		const requestType = this.foundData[0].requestType;
+
+		let firstOption = `<option value="연차">🏖️ 연차</option>`;
+		let secondOption = `<option value="반차">🌇 반차</option>`;
+		let thirdOption = `<option value="병가">🚑 병가</option>`;
+		let fourthOption = `<option value="기타">💬 기타</option>`;
+		let template = ``;
+
+		switch (true) {
+			case requestType === '연차':
+				firstOption = `<option value="연차" selected>🏖️ 연차</option>`;
+				template = `${firstOption}${secondOption}${thirdOption}${fourthOption}`;
+				break;
+			case requestType === '반차':
+				secondOption = `<option value="반차" selected>🌇 반차</option>`;
+				template = `${firstOption}${secondOption}${thirdOption}${fourthOption}`;
+				break;
+			case requestType === '병가':
+				thirdOption = `<option value="병가" selected>🚑 병가</option>`;
+				template = `${firstOption}${secondOption}${thirdOption}${fourthOption}`;
+				break;
+			case requestType === '기타':
+				fourthOption = `<option value="기타" selected>💬 기타</option>`;
+				template = `${firstOption}${secondOption}${thirdOption}${fourthOption}`;
+				break;
+		}
+		return template;
+	}
+
+	closeHistoryModal() {
+		const historyModal = document.getElementById('historyModal');
+		historyModal.classList.remove('active');
+	}
+
 	render() {
 		this.modalWrapper.insertAdjacentHTML('beforeend', this.template);
+		const historyModal = document.getElementById('historyModal');
+		const vacationSelectTag = historyModal.querySelector('#vacationSelect');
+		const vacationDescription = historyModal.querySelector('textarea');
+		const historyOkBtn = document.querySelector('#historyModalBtnWrapper button');
+		const dateInputs = historyModal.querySelectorAll('input[type="date"]');
+		const startDateInput = dateInputs[0];
+		const endDateInput = dateInputs[1];
+
+		const titleInput = historyModal.querySelector('#title');
+		titleInput.value = this.foundData[0].title;
+
+		vacationSelectTag.innerHTML = this.setRequestType();
+
+		startDateInput.value = this.foundData[0].startDate;
+		endDateInput.value = this.foundData[0].endDate;
+
+		vacationDescription.innerText = this.foundData[0].body;
+
+		historyOkBtn.addEventListener('click', this.closeHistoryModal);
 	}
 }

--- a/src/pages/vacation/components/VacationListItem.js
+++ b/src/pages/vacation/components/VacationListItem.js
@@ -1,4 +1,5 @@
 import AvatarImg from '/public/avatar.svg';
+import VacationHistoryModal from '../VacationHistoryModal';
 
 export default class VacationListItem {
 	constructor(parentEl, isMyType, filterType) {
@@ -72,9 +73,25 @@ export default class VacationListItem {
 		return result;
 	}
 
+	async showHistoryModal(event) {
+		const modalWrapper = document.querySelector('#modalWrapper');
+		const liEl = event.target.closest('li');
+		const liKey = liEl.getAttribute('data-key');
+
+		const vacationDatas = await this.fetchVacationData();
+		const foundData = vacationDatas.filter((data) => data.requestId === liKey);
+
+		new VacationHistoryModal(modalWrapper, foundData).render();
+		const historyModal = modalWrapper.querySelector('#historyModal');
+		historyModal.classList.add('active');
+	}
+
 	async render() {
 		const data = this.isMyType ? await this.filterMyData() : await this.fetchVacationData();
 
 		this.parentEl.innerHTML = this.getVacationList(data);
+		this.parentEl.addEventListener('click', (event) => {
+			this.showHistoryModal(event);
+		});
 	}
 }

--- a/src/pages/vacation/index.js
+++ b/src/pages/vacation/index.js
@@ -1,13 +1,10 @@
 import VacationListItem from './components/VacationListItem';
 import './style.css';
 import VacationApplyModal from './VacationApplyModal';
-import VacationHistoryModal from './VacationHistoryModal';
 
 export default class VacationPage {
 	constructor(contents) {
 		this.contentsElement = contents;
-		this.applyModalEl = new VacationApplyModal();
-		this.historyModalEl = new VacationHistoryModal();
 		this.template = `
             <section class="contents vacation">
                 <div class="vacation__page-title-wrapper">
@@ -62,7 +59,7 @@ export default class VacationPage {
             `;
 	}
 
-	showModal(event) {
+	showModal() {
 		const applyModal = document.getElementById('applyModal');
 		applyModal.classList.add('active');
 	}
@@ -92,25 +89,23 @@ export default class VacationPage {
 
 		// 리스트 렌더링
 		this.vacationListEl = document.querySelector('#vacationList');
+		this.modalWrapper = document.querySelector('#modalWrapper');
 		this.fetchVacationList();
 
-		const el = document.querySelector('#modalWrapper');
-
-		new VacationApplyModal(el).render();
-		new VacationHistoryModal(el).render();
+		// 근태 신청 모달 렌더링
+		new VacationApplyModal(this.modalWrapper).render();
 
 		const applyModalBtnWrapper = document.getElementById('applyModalBtnWrapper');
 		const applyModalCancelBtn = applyModalBtnWrapper.querySelector('button:first-child');
-		const historyModalBtnWrapper = document.getElementById('historyModalBtnWrapper');
-		const historyModalCancelBtn = historyModalBtnWrapper.querySelector('button:first-child');
 
+		// 근태 신청 모달 팝업
 		const openApplyModalBtns = document.querySelectorAll('[data-button="register"]');
 		openApplyModalBtns.forEach((btn) => {
 			btn.addEventListener('click', this.showModal); // 실행 컨텍스트 문제로 this.showModal 내부의 this는 실행 주체인 openApplyModalBtn이 됨
 		});
 
+		// 근태 신청 모달 닫기
 		applyModalCancelBtn.addEventListener('click', this.closeModal);
-		historyModalCancelBtn.addEventListener('click', this.closeModal);
 
 		// 나의 근태 목록 필터링
 		const myVacationBtn = document.querySelector('#myVacationBtn');

--- a/src/pages/vacation/style.css
+++ b/src/pages/vacation/style.css
@@ -37,8 +37,8 @@
 	flex-direction: column;
 	gap: 12px;
 	flex: 1;
-    height: 100%;
-    overflow-y: scroll;
+	height: 100%;
+	overflow-y: scroll;
 }
 
 .vacation__list-nav {
@@ -70,11 +70,14 @@
 	flex-grow: 1;
 }
 
+.vacation__list-main li {
+	padding: 6px 0;
+}
+
 .vacation__main-item {
 	display: flex;
 	align-items: center;
 	padding: 16px 24px;
-	margin-bottom: 12px;
 	border-radius: 24px;
 	background-color: #f9f8f6;
 }
@@ -83,7 +86,7 @@
 	margin-right: 20px;
 }
 
-.vacation__main-item--profile img{
+.vacation__main-item--profile img {
 	width: 60px;
 	height: 60px;
 }
@@ -110,9 +113,9 @@
 
 .vacation__main-item--desc {
 	white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    padding-right: var(--padding-sm);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding-right: var(--padding-sm);
 	line-height: 18px;
 	flex-grow: 1;
 }
@@ -131,7 +134,6 @@
 	font-size: 14px;
 	margin-right: 48px;
 }
-
 
 .vacation__main-item--author {
 	color: var(--color-secondary);
@@ -338,6 +340,17 @@
 	padding: 5px 0;
 }
 
+.vacation__history-wrapper.active input[type='date']::before {
+	content: '';
+	width: 0;
+	position: static;
+	top: 0;
+	left: 0;
+	transform: none;
+	background-color: inherit;
+	padding: 0;
+}
+
 .vacation__apply-form-wrapper input[type='date']:focus::before,
 .vacation__apply-form-wrapper input[type='date']:valid::before {
 	display: none;
@@ -369,8 +382,7 @@
 	padding: 8px 44px;
 }
 
-.vacation__apply-btn-wrapper button:first-child,
-.vacation__history-btn-wrapper button:first-child {
+.vacation__apply-btn-wrapper button:first-child {
 	margin-right: 16px;
 }
 
@@ -395,7 +407,7 @@
 		padding: 12px;
 	}
 
-	.vacation__main-item--profile img{
+	.vacation__main-item--profile img {
 		width: 45px;
 		height: 45px;
 	}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[개별 근태 신청 내역 모달 구현]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
* 개별 근태 신청 페이지 리스트 아이템 클릭 시 신청 내역 모달창 팝업
* 개별 근태 신청 페이지 리스트 아이템 클릭 시 `requestId`를 불러와 폼에 맞게 데이터 입력
* 개별 근태 신청 페이지 리스트 모달창의 확인 버튼 클릭 시 모달창 닫기 이벤트

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.
 - [x] 개별 근태 신청 페이지 내역 클릭 시 신청 내역 모달창 팝업
 - [x] 서버에서 받아온 데이터 폼에 맞게 입력
 - [x] 근태 신청 내역 페이지 내 확인 버튼 클릭 시 모달창 닫기

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
