### PR TITLE
[🔨 Refactor] 근태 신청 모달 생성자 함수 내부 변수명 변경 및 폼 제출 이벤트리스너 콜백 함수 스타일 변경

### DIFF
--- a/src/components/pages/vacation/vacationApplyModal.js
+++ b/src/components/pages/vacation/vacationApplyModal.js
@@ -1,6 +1,6 @@
 export default class VacationApplyModal {
-	constructor(modalWrapper) {
-		this.modalWrapper = modalWrapper;
+	constructor(modalParentEl) {
+		this.modalParentEl = modalParentEl;
 		this.template = `
             <div class="vacation__apply-wrapper" id="applyModal">
                 <div class="vacation__apply-background"></div>
@@ -42,7 +42,7 @@ export default class VacationApplyModal {
 
 	async handleVacationSubmit(event) {
 		event.preventDefault();
-		const vacationApplyModal = document.getElementById('applyModal');
+		const vacationApplyModal = this.modalParentEl.querySelector('#applyModal');
 		const submitArray = [];
 		const submitObject = {};
 		const formData = new FormData(this);
@@ -67,9 +67,11 @@ export default class VacationApplyModal {
 	}
 
 	async render() {
-		this.modalWrapper.insertAdjacentHTML('beforeend', this.template);
-		const vacationApplyForm = document.getElementById('vacationApplyForm');
+		this.modalParentEl.insertAdjacentHTML('beforeend', this.template);
+		const vacationApplyForm = document.querySelector('#vacationApplyForm');
 
-		vacationApplyForm.addEventListener('submit', this.handleVacationSubmit);
+		vacationApplyForm.addEventListener('submit', () => {
+			this.handleVacationSubmit;
+		});
 	}
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

**[작업 내용을 간략히 적어주세요]**

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
* 기존 변수명을 직관성 있는 변수명으로 변경
* 근태 신청 창의 form에 연결된 이벤트리스너의 콜백 함수를 함수 선언문 형식에서 this 바인딩을 사용하기 위한 화살표 함수 스타일로 변경

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.
- [x] VacationApplyModal 클래스의 생성자로 받아오는 상위 #modalWrapper 요소의 변수명 변경
- [x] vacationApplyForm의 eventListener의 두 번째 인수인 handleVacationSubmit 이벤트를 화살표 함수로 변경


## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부할 수 있습니다.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
