### PR TITLE
[🐞 Bug] router 상태관리자를 생성되기 전에 import 해서 에러가 나는 이슈 수정 

### DIFF
--- a/src/components/layout/layout/index.js
+++ b/src/components/layout/layout/index.js
@@ -1,5 +1,4 @@
 import { route, navigate, url } from '../../../router';
-import { default as routerManager } from '../../../services/routerManager';
 import Navigation from '../navigation';
 import LoginStatus from '../loginStatus';
 import './style.css';
@@ -39,12 +38,7 @@ export default class Layout {
 			navEl.addEventListener('click', navigate);
 		});
 
-		window.addEventListener('popstate', () => {
-			routerManager.setState({
-				path: window.location.pathname,
-			});
-			route();
-		});
+		window.addEventListener('popstate', route);
 		route();
 	}
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

이전 [PR #138](https://github.com/Dev-FE-2/toy-project1-team4-intranet-project/issues/140) 에서 router 전역 상태관리자를 미리 만들었으나 PR에 포함하지 않았습니다. 그러나 관련된 컴포넌트에서 import 하는 것을 수정하지 않아 에러가 나고 있습니다.

## 📋 작업 내용

수정한 내용이나 추가한 기능에 대해 자세히 설명해 주세요.
- 버그 수정

## 🔧 변경 사항

주요 변경 사항을 요약해 주세요.
- router/route.js 사용하지 않는 모듈 제거


## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/8ec041bf-f2b5-466a-b237-2a1e4f74aaed)

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
